### PR TITLE
Fix: Correct Docker repository URLs for RedHat family

### DIFF
--- a/roles/docker_host/tasks/main.yml
+++ b/roles/docker_host/tasks/main.yml
@@ -57,10 +57,12 @@
   ansible.builtin.yum_repository:
     name: docker-ce
     description: Docker CE Repository
-    baseurl: https://download.docker.com/linux/centos/$releasever/$basearch/stable
+    baseurl: "https://download.docker.com/linux/{{ dist_path_component }}/$releasever/$basearch/stable"
     gpgcheck: true
-    gpgkey: https://download.docker.com/linux/centos/gpg
+    gpgkey: "https://download.docker.com/linux/{{ dist_path_component }}/gpg"
     enabled: true
+  vars:
+    dist_path_component: "{{ 'fedora' if ansible_distribution == 'Fedora' else ('rhel' if ansible_distribution in ['RedHat Enterprise Linux', 'RHEL'] else (ansible_distribution | lower)) }}"
   when: ansible_os_family == "RedHat"
   tags:
     - docker


### PR DESCRIPTION
The Docker repository configuration for RedHat family distributions was previously hardcoded to use 'centos' in the baseurl and gpgkey URLs. This would cause Docker installation to fail on other RedHat-based distributions like RHEL and Fedora.

This change makes the distribution component of the URLs dynamic by introducing a variable `dist_path_component`. This variable is set based on `ansible_distribution`:
- 'fedora' for Fedora
- 'rhel' for RHEL (and 'RedHat Enterprise Linux')
- Lowercase `ansible_distribution` for others (e.g., 'centos', 'almalinux')

This ensures the correct repository and GPG key URLs are used, allowing Docker to be installed correctly across a wider range of RedHat family distributions.